### PR TITLE
Switch to Docker onbuild for development

### DIFF
--- a/Dockerfile-Dev
+++ b/Dockerfile-Dev
@@ -1,10 +1,1 @@
-FROM golang:1.5.3
-
-ENV GO15VENDOREXPERIMENT=1
-
-RUN mkdir -p /go/src/github.com/dcondomitti/csp
-WORKDIR /go/src/github.com/dcondomitti/csp
-
-EXPOSE 8080
-
-CMD go run -ldflags "-X main.revision=$(git rev-parse HEAD)" *.go
+FROM golang:1.5.3-onbuild


### PR DESCRIPTION
After cloning the repository and starting the service with ```docker-compose up -d```, the container immediately exits.

I get the following output:

```
> docker-compose logs
Attaching to csp_app_1
app_1  | go run: cannot run *_test.go files (report_test.go)
```

This pull request switches the Docker dev environment to use the `golang:onbuild` image instead (See https://hub.docker.com/_/golang/).